### PR TITLE
Remove debug console logs from form submission script

### DIFF
--- a/resources/views/declaration/formulaire.blade.php
+++ b/resources/views/declaration/formulaire.blade.php
@@ -921,11 +921,6 @@
             const constatCheckbox = document.getElementById('constat');
             formData.set('constat_autorite', constatCheckbox.checked ? '1' : '0');
 
-            console.log('FormData contents:');
-            for (let [key, value] of formData.entries()) {
-                console.log(key + ':', value);
-            }
-
             const submitUrl = '/declaration/store';
 
             fetch(submitUrl, {
@@ -957,8 +952,6 @@
                     return response.json();
                 })
                 .then(data => {
-                    console.log('Success response:');
-
                     if (data.success) {
                         showSuccessPage(data);
                     } else {


### PR DESCRIPTION
Eliminated unnecessary console.log statements from the formulaire.blade.php JavaScript to clean up browser console output during form submission.