### PR TITLE
Refactor sinistre email notification to queued job

### DIFF
--- a/app/Jobs/SendSinistreNotificationEmail.php
+++ b/app/Jobs/SendSinistreNotificationEmail.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Jobs;
+
+use Exception;
+use App\Models\Sinistre;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class SendSinistreNotificationEmail implements ShouldQueue
+{
+    use Queueable, Dispatchable, InteractsWithQueue, SerializesModels;
+
+    protected $sinistre;
+    protected $gestionnaires;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(Sinistre $sinistre, $gestionnaires)
+    {
+        $this->sinistre = $sinistre;
+        $this->gestionnaires = $gestionnaires;
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        try {
+            $dataEmail = [
+                'sinistre' => $this->sinistre,
+                'url_sinistre' => route('dashboard'),
+                'company' => [
+                    'name' => 'SAAR ASSURANCE',
+                    'phone' => '+225 20 30 30 30',
+                    'email' => 'contact@saar-assurance.ci',
+                    'address' => 'Abidjan, Côte d\'Ivoire'
+                ]
+            ];
+
+            foreach ($this->gestionnaires as $gestionnaire) {
+                try {
+                    Mail::send('emails.nouveau-sinistre', $dataEmail, function ($message) use ($gestionnaire) {
+                        $message->to($gestionnaire->email, $gestionnaire->nom_complet)
+                            ->subject('Nouveau sinistre déclaré - N° ' . $this->sinistre->numero_sinistre)
+                            ->from(config('mail.from.address'), config('mail.from.name'));
+                    });
+                } catch (Exception $e) {
+                    Log::error('Erreur lors de l\'envoi d\'email à un gestionnaire', [
+                        'gestionnaire_email' => $gestionnaire->email,
+                        'sinistre_id' => $this->sinistre->id,
+                        'numero_sinistre' => $this->sinistre->numero_sinistre,
+                        'error' => $e->getMessage()
+                    ]);
+
+
+                    throw $e;
+                }
+            }
+        } catch (Exception $e) {
+            Log::error('Erreur générale lors de l\'envoi des emails aux gestionnaires', [
+                'sinistre_id' => $this->sinistre->id,
+                'numero_sinistre' => $this->sinistre->numero_sinistre,
+                'error' => $e->getMessage()
+            ]);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Handle a job failure.
+     *
+     * This method is triggered when the queue job fails after all retry attempts.
+     * It logs an error message with details about the sinistre and the error
+     * that caused the failure.
+     *
+     * @param Exception $exception The exception that caused the job to fail.
+     */
+
+    public function failed(Exception $exception): void
+    {
+        Log::error('Job d\'envoi d\'email échoué définitivement', [
+            'sinistre_id' => $this->sinistre->id,
+            'numero_sinistre' => $this->sinistre->numero_sinistre,
+            'error' => $exception->getMessage()
+        ]);
+    }
+}

--- a/app/Services/OrangeService.php
+++ b/app/Services/OrangeService.php
@@ -217,7 +217,7 @@ class OrangeService
                 'outboundSMSMessageRequest' => [
                     'address' => 'tel:+' . $recipientWithoutPlus,
                     'senderAddress' => 'tel:+' . $countrySenderNumber,
-                    'senderName' => 'SAAR ASSURANCE CÔTE D\'IVOIRE',
+                    'senderName' => 'SAAR CI',
                     'outboundSMSTextMessage' => [
                         'message' => $message,
                     ],

--- a/config/queue.php
+++ b/config/queue.php
@@ -52,6 +52,15 @@ return [
             'after_commit' => false,
         ],
 
+        'emails' => [
+            'driver' => 'database',
+            'connection' => env('DB_QUEUE_CONNECTION'),
+            'table' => env('DB_QUEUE_TABLE', 'jobs'),
+            'queue' => 'emails',
+            'retry_after' => (int) env('DB_QUEUE_RETRY_AFTER', 90),
+            'after_commit' => false,
+        ],
+
         'sqs' => [
             'driver' => 'sqs',
             'key' => env('AWS_ACCESS_KEY_ID'),


### PR DESCRIPTION
Moved the sinistre notification email logic from DeclarationController to a dedicated SendSinistreNotificationEmail job for better separation and reliability. Added error handling and logging to the job. Updated queue configuration to add an 'emails' queue. Changed SMS sender name in OrangeService to 'SAAR CI'.