### PR TITLE
Refactor DeclarationController to use service classes

### DIFF
--- a/app/Console/Commands/MakeServiceCommand.php
+++ b/app/Console/Commands/MakeServiceCommand.php
@@ -65,10 +65,7 @@ namespace App\Services;
 
 class {$name}
 {
-    public function handle()
-    {
-        // Handle the service logic
-    }
+    //
 }
 
 EOT;

--- a/app/Http/Controllers/DeclarationController.php
+++ b/app/Http/Controllers/DeclarationController.php
@@ -3,22 +3,34 @@
 namespace App\Http\Controllers;
 
 use Exception;
-use App\Models\User;
 use App\Models\Sinistre;
-use Illuminate\Http\Request;
-use Barryvdh\DomPDF\Facade\Pdf;
-use App\Models\DocumentSinistre;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
-use App\Jobs\SendAccountCreationSms;
-use Illuminate\Support\Facades\Hash;
-use App\Jobs\SendSinistreConfirmationSms;
-use App\Jobs\SendSinistreNotificationEmail;
+use App\Services\NotificationService;
+use App\Services\AssureAccountService;
+use App\Services\PdfGenerationService;
+use App\Services\SinistreDocumentService;
 use App\Http\Requests\StoreDeclarationRequest;
 
 class DeclarationController extends Controller
 {
+    protected $accountService;
+    protected $documentService;
+    protected $notificationService;
+    protected $pdfService;
+
+    public function __construct(
+        AssureAccountService $accountService,
+        SinistreDocumentService $documentService,
+        NotificationService $notificationService,
+        PdfGenerationService $pdfService
+    ) {
+        $this->accountService = $accountService;
+        $this->documentService = $documentService;
+        $this->notificationService = $notificationService;
+        $this->pdfService = $pdfService;
+    }
 
     public function create()
     {
@@ -30,15 +42,11 @@ class DeclarationController extends Controller
         try {
             DB::beginTransaction();
 
-            $user = $this->creerCompteAssure($request->validated());
+            $user = $this->accountService->createAssureAccount($request->validated());
+            $sinistre = $this->createSinistre($request->validated() + ['assure_id' => $user->id]);
 
-            SendAccountCreationSms::dispatch($user, $request->telephone_assure);
-
-            $sinistre = $this->creerSinistre($request->validated() + ['assure_id' => $user->id]);
-
-            $this->gererDocuments($request, $sinistre);
-
-            $this->declencherNotifications($sinistre);
+            $this->documentService->handleDocuments($request, $sinistre);
+            $this->notificationService->triggerSinistreNotifications($sinistre);
 
             DB::commit();
 
@@ -60,7 +68,7 @@ class DeclarationController extends Controller
         }
     }
 
-    private function creerSinistre(array $validated): Sinistre
+    protected function createSinistre(array $validated): Sinistre
     {
         $donneesSinistre = collect($validated)->except([
             'carte_grise_recto',
@@ -73,200 +81,24 @@ class DeclarationController extends Controller
         ])->toArray();
 
         $donneesSinistre['constat_autorite'] = (bool)($donneesSinistre['constat_autorite'] ?? false);
-
         $donneesSinistre['statut'] = 'en_attente';
 
         return Sinistre::create($donneesSinistre);
     }
 
-    private function gererDocuments(Request $request, Sinistre $sinistre): void
-    {
-        $typesDocuments = [
-            'carte_grise_recto' => 'Carte grise (Recto)',
-            'carte_grise_verso' => 'Carte grise (Verso)',
-            'visite_technique_recto' => 'Visite technique (Recto)',
-            'visite_technique_verso' => 'Visite technique (Verso)',
-            'attestation_assurance' => 'Attestation d\'assurance',
-            'permis_conduire' => 'Permis de conduire'
-        ];
-
-        foreach ($typesDocuments as $typeInput => $libelle) {
-            if ($request->hasFile($typeInput)) {
-                $this->stockerDocument($request->file($typeInput), $sinistre, $typeInput, $libelle);
-            }
-        }
-
-        if ($request->hasFile('photos_vehicule')) {
-            foreach ($request->file('photos_vehicule') as $index => $photo) {
-                $libelle = "Photo véhicule " . ($index + 1);
-                $this->stockerDocument($photo, $sinistre, 'photo_vehicule', $libelle);
-            }
-        }
-    }
-
-    private function stockerDocument($file, Sinistre $sinistre, string $type, string $libelle): void
-    {
-        $extension = $file->getClientOriginalExtension();
-        $nomFichier = $type . '_' . time() . '_' . uniqid() . '.' . $extension;
-
-        $chemin = $file->storeAs("sinistres/{$sinistre->id}", $nomFichier, 'public');
-
-        DocumentSinistre::create([
-            'sinistre_id' => $sinistre->id,
-            'type_document' => $type,
-            'libelle_document' => $libelle,
-            'nom_fichier' => $file->getClientOriginalName(),
-            'nom_fichier_stocke' => $nomFichier,
-            'chemin_fichier' => $chemin,
-            'type_mime' => $file->getMimeType(),
-            'taille_fichier' => $file->getSize(),
-        ]);
-    }
-
     public function downloadRecu($sinistreId)
     {
         try {
-            $sinistre = Sinistre::with('documents')->findOrFail($sinistreId);
-
-            $data = [
-                'sinistre' => $sinistre,
-                'date_generation' => now()->format('d/m/Y H:i'),
-                'company' => [
-                    'name' => 'SAAR ASSURANCE',
-                    'phone' => '+225 20 30 30 30',
-                    'email' => 'contact@saar-assurance.ci',
-                    'address' => 'Abidjan, Côte d\'Ivoire'
-                ]
-            ];
-
-            $pdf = PDF::loadView('declaration.recu-pdf', $data);
-
-            $pdf->setPaper('A4', 'portrait');
-
-            $nomFichier = 'Recu_Declaration_' . $sinistre->numero_sinistre . '.pdf';
-
-            return $pdf->download($nomFichier);
+            return $this->pdfService->generateSinistreReceipt($sinistreId);
         } catch (Exception $e) {
             Log::error('Erreur lors du téléchargement du reçu: ' . $e->getMessage());
-
             return redirect()->back()->with('error', 'Impossible de générer le reçu. Veuillez réessayer.');
         }
     }
 
-    private function declencherNotifications(Sinistre $sinistre): void
-    {
-        try {
-            //SEND EMAIL TO GESTIONNAIRES
-            $this->sendEmail($sinistre);
-
-            //SEND SMS TO ASSURE
-            SendSinistreConfirmationSms::dispatch($sinistre);
-
-            // $this->declencherWorkflowN8n('nouveau_sinistre', $sinistre);
-        } catch (Exception $e) {
-            Log::error('Erreur lors des notifications: ' . $e->getMessage());
-        }
-    }
-
-    private function genererNumeroAssure(): string
-    {
-        $characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-        $randdomString = '';
-        $prefix = 'SAAR-';
-
-        for ($i = 0; $i < 4; $i++) {
-            $randdomString .= $characters[rand(0, strlen($characters) - 1)];
-        }
-
-        return $prefix . $randdomString;
-    }
-
-    private function genererMotDePasseTemporaire(): string
-    {
-        return str_pad(rand(0, 999999), 6, '0', STR_PAD_LEFT);
-    }
-
-    private function creerCompteAssure(array $data): User
-    {
-        $numeroAssure = $this->genererNumeroAssure();
-        $motDePasseTemporaire = $this->genererMotDePasseTemporaire();
-
-        $user = User::create([
-            'numero_assure' => $numeroAssure,
-            'nom_complet' => $data['nom_assure'],
-            'email' => $data['email_assure'] ?? null,
-            'password' => Hash::make($motDePasseTemporaire),
-            'password_temp' => $motDePasseTemporaire,
-            'password_expires_at' => now()->addHours(48),
-            'role' => 'assure',
-        ]);
-
-        return $user;
-    }
-
-    private function sendEmail(Sinistre $sinistre)
-    {
-        try {
-            $gestionnaires = User::where('role', 'gestionnaire')
-                ->where('actif', true)
-                ->get();
-
-            if ($gestionnaires->isEmpty()) {
-                Log::warning('Aucun gestionnaire actif trouvé', [
-                    'sinistre_id' => $sinistre->id,
-                    'numero_sinistre' => $sinistre->numero_sinistre
-                ]);
-                return;
-            }
-
-            SendSinistreNotificationEmail::dispatch($sinistre, $gestionnaires)
-                ->delay(now()->addSeconds(5));
-
-            Log::info('Job d\'envoi d\'email planifié avec succès', [
-                'sinistre_id' => $sinistre->id,
-                'numero_sinistre' => $sinistre->numero_sinistre,
-                'nb_gestionnaires' => $gestionnaires->count()
-            ]);
-        } catch (Exception $e) {
-            Log::error('Erreur lors de l\'envoi des emails aux gestionnaires: ' . $e->getMessage(), [
-                'sinistre_id' => $sinistre->id,
-                'numero_sinistre' => $sinistre->numero_sinistre,
-                'error' => $e->getMessage()
-            ]);
-        }
-    }
-
-    // private function sendSmsConfirmation(Sinistre $sinistre): void
-    // {
-    //     try {
-    //         if (empty($sinistre->telephone_assure)) {
-    //             Log::warning('Numéro de téléphone manquant pour le sinistre', [
-    //                 'sinistre_id' => $sinistre->id,
-    //                 'numero_sinistre' => $sinistre->numero_sinistre
-    //             ]);
-    //             return;
-    //         }
-
-    //         $orangeService = app(\App\Services\OrangeService::class);
-
-    //         $orangeService->sendSmsConfirmationSinistre(
-    //             $sinistre->telephone_assure,
-    //             $sinistre->nom_assure,
-    //             $sinistre->numero_sinistre
-    //         );
-    //     } catch (Exception $e) {
-    //         Log::error('Erreur lors de l\'envoi du SMS de confirmation', [
-    //             'sinistre_id' => $sinistre->id,
-    //             'numero_sinistre' => $sinistre->numero_sinistre,
-    //             'error' => $e->getMessage()
-    //         ]);
-    //     }
-    // }
-
     public function confirmation($sinistreId)
     {
         $sinistre = Sinistre::with('documents')->findOrFail($sinistreId);
-
         return view('declaration.confirmation', compact('sinistre'));
     }
 

--- a/app/Services/AssureAccountService.php
+++ b/app/Services/AssureAccountService.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+use App\Jobs\SendAccountCreationSms;
+use Illuminate\Support\Facades\Hash;
+
+class AssureAccountService
+{
+    public function createAssureAccount(array $data): User
+    {
+        $numeroAssure = $this->generateAssureNumber();
+        $motDePasseTemporaire = $this->generateTemporaryPassword();
+
+        $user = User::create([
+            'numero_assure' => $numeroAssure,
+            'nom_complet' => $data['nom_assure'],
+            'email' => $data['email_assure'] ?? null,
+            'password' => Hash::make($motDePasseTemporaire),
+            'password_temp' => $motDePasseTemporaire,
+            'password_expires_at' => now()->addHours(48),
+            'role' => 'assure',
+        ]);
+
+        SendAccountCreationSms::dispatch($user, $data['telephone_assure']);
+
+        return $user;
+    }
+
+
+    protected function generateAssureNumber(): string
+    {
+        $characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+        $randomString = '';
+        $prefix = 'SAAR-';
+
+        for ($i = 0; $i < 4; $i++) {
+            $randomString .= $characters[rand(0, strlen($characters) - 1)];
+        }
+
+        return $prefix . $randomString;
+    }
+
+    protected function generateTemporaryPassword(): string
+    {
+        return str_pad(rand(0, 999999), 6, '0', STR_PAD_LEFT);
+    }
+}

--- a/app/Services/NotificationService.php
+++ b/app/Services/NotificationService.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Services;
+
+use Exception;
+use App\Models\User;
+use App\Models\Sinistre;
+use Illuminate\Support\Facades\Log;
+use App\Jobs\SendSinistreConfirmationSms;
+use App\Jobs\SendSinistreNotificationEmail;
+
+class NotificationService
+{
+    public function triggerSinistreNotifications(Sinistre $sinistre): void
+    {
+        $this->sendEmailToManagers($sinistre);
+        $this->sendSmsToAssure($sinistre);
+    }
+
+    protected function sendEmailToManagers(Sinistre $sinistre): void
+    {
+        try {
+            $gestionnaires = User::where('role', 'gestionnaire')
+                ->where('actif', true)
+                ->get();
+
+            if ($gestionnaires->isEmpty()) {
+                Log::warning('Aucun gestionnaire actif trouvé', [
+                    'sinistre_id' => $sinistre->id,
+                    'numero_sinistre' => $sinistre->numero_sinistre
+                ]);
+                return;
+            }
+
+            SendSinistreNotificationEmail::dispatch($sinistre, $gestionnaires)
+                ->delay(now()->addSeconds(5));
+
+            Log::info('Job d\'envoi d\'email planifié avec succès', [
+                'sinistre_id' => $sinistre->id,
+                'numero_sinistre' => $sinistre->numero_sinistre,
+                'nb_gestionnaires' => $gestionnaires->count()
+            ]);
+        } catch (Exception $e) {
+            Log::error('Erreur lors de l\'envoi des emails aux gestionnaires: ' . $e->getMessage(), [
+                'sinistre_id' => $sinistre->id,
+                'numero_sinistre' => $sinistre->numero_sinistre,
+                'error' => $e->getMessage()
+            ]);
+        }
+    }
+
+    protected function sendSmsToAssure(Sinistre $sinistre): void
+    {
+        try {
+            SendSinistreConfirmationSms::dispatch($sinistre);
+        } catch (Exception $e) {
+            Log::error('Erreur lors de l\'envoi du SMS de confirmation', [
+                'sinistre_id' => $sinistre->id,
+                'numero_sinistre' => $sinistre->numero_sinistre,
+                'error' => $e->getMessage()
+            ]);
+        }
+    }
+}

--- a/app/Services/PdfGenerationService.php
+++ b/app/Services/PdfGenerationService.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Sinistre;
+use Barryvdh\DomPDF\Facade\Pdf;
+
+class PdfGenerationService
+{
+    public function generateSinistreReceipt($sinistreId)
+    {
+        $sinistre = Sinistre::with('documents')->findOrFail($sinistreId);
+
+        $data = [
+            'sinistre' => $sinistre,
+            'date_generation' => now()->format('d/m/Y H:i'),
+            'company' => [
+                'name' => 'SAAR ASSURANCE',
+                'phone' => '+225 20 30 30 30',
+                'email' => 'contact@saar-assurance.ci',
+                'address' => 'Abidjan, Côte d\'Ivoire'
+            ]
+        ];
+
+        $pdf = PDF::loadView('declaration.recu-pdf', $data);
+        $pdf->setPaper('A4', 'portrait');
+
+        $nomFichier = 'Recu_Declaration_' . $sinistre->numero_sinistre . '.pdf';
+
+        return $pdf->download($nomFichier);
+    }
+}

--- a/app/Services/SinistreDocumentService.php
+++ b/app/Services/SinistreDocumentService.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Sinistre;
+use Illuminate\Http\Request;
+use App\Models\DocumentSinistre;
+
+class SinistreDocumentService
+{
+    public function handleDocuments(Request $request, Sinistre $sinistre): void
+    {
+        $this->processStandardDocuments($request, $sinistre);
+        $this->processVehiclePhotos($request, $sinistre);
+    }
+
+    protected function processStandardDocuments(Request $request, Sinistre $sinistre): void
+    {
+        $typesDocuments = [
+            'carte_grise_recto' => 'Carte grise (Recto)',
+            'carte_grise_verso' => 'Carte grise (Verso)',
+            'visite_technique_recto' => 'Visite technique (Recto)',
+            'visite_technique_verso' => 'Visite technique (Verso)',
+            'attestation_assurance' => 'Attestation d\'assurance',
+            'permis_conduire' => 'Permis de conduire'
+        ];
+
+        foreach ($typesDocuments as $typeInput => $libelle) {
+            if ($request->hasFile($typeInput)) {
+                $this->storeDocument($request->file($typeInput), $sinistre, $typeInput, $libelle);
+            }
+        }
+    }
+
+    protected function processVehiclePhotos(Request $request, Sinistre $sinistre): void
+    {
+        if ($request->hasFile('photos_vehicule')) {
+            foreach ($request->file('photos_vehicule') as $index => $photo) {
+                $libelle = "Photo véhicule " . ($index + 1);
+                $this->storeDocument($photo, $sinistre, 'photo_vehicule', $libelle);
+            }
+        }
+    }
+
+    protected function storeDocument($file, Sinistre $sinistre, string $type, string $libelle): void
+    {
+        $extension = $file->getClientOriginalExtension();
+        $nomFichier = $type . '_' . time() . '_' . uniqid() . '.' . $extension;
+
+        $chemin = $file->storeAs("sinistres/{$sinistre->id}", $nomFichier, 'public');
+
+        DocumentSinistre::create([
+            'sinistre_id' => $sinistre->id,
+            'type_document' => $type,
+            'libelle_document' => $libelle,
+            'nom_fichier' => $file->getClientOriginalName(),
+            'nom_fichier_stocke' => $nomFichier,
+            'chemin_fichier' => $chemin,
+            'type_mime' => $file->getMimeType(),
+            'taille_fichier' => $file->getSize(),
+        ]);
+    }
+}


### PR DESCRIPTION
Moved account creation, document handling, notification, and PDF generation logic from DeclarationController into dedicated service classes (AssureAccountService, SinistreDocumentService, NotificationService, PdfGenerationService) for better separation of concerns and maintainability. Updated controller to use these services via dependency injection. Also simplified MakeServiceCommand stub generation.