### PR TITLE
Update declaration receipt to attestation and adjust texts

### DIFF
--- a/app/Models/Sinistre.php
+++ b/app/Models/Sinistre.php
@@ -103,7 +103,7 @@ class Sinistre extends Model
         $annee = date('Y');
         $compteur = static::whereYear('created_at', $annee)->count() + 1;
 
-        return 'SIN-' . $annee . '-' . str_pad($compteur, 5, '0', STR_PAD_LEFT);
+        return 'APP-' . str_pad($compteur, 5, '0', STR_PAD_LEFT) . '-' . $annee;
     }
 
     /**

--- a/app/Services/PdfGenerationService.php
+++ b/app/Services/PdfGenerationService.php
@@ -25,7 +25,7 @@ class PdfGenerationService
         $pdf = PDF::loadView('declaration.recu-pdf', $data);
         $pdf->setPaper('A4', 'portrait');
 
-        $nomFichier = 'Recu_Declaration_' . $sinistre->numero_sinistre . '.pdf';
+        $nomFichier = 'Attestation_Declaration_' . $sinistre->numero_sinistre . '.pdf';
 
         return $pdf->download($nomFichier);
     }

--- a/resources/views/declaration/confirmation.blade.php
+++ b/resources/views/declaration/confirmation.blade.php
@@ -158,8 +158,8 @@
                             class="flex-shrink-0 w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-bold mr-4">
                             1</div>
                         <div>
-                            <p class="font-semibold text-gray-900">Confirmation par email</p>
-                            <p class="text-sm text-gray-600">Vous recevrez un email de confirmation avec tous les
+                            <p class="font-semibold text-gray-900">Confirmation par sms</p>
+                            <p class="text-sm text-gray-600">Vous recevrez un sms de confirmation avec tous les
                                 détails dans quelques minutes.</p>
                         </div>
                     </div>
@@ -170,7 +170,7 @@
                             2</div>
                         <div>
                             <p class="font-semibold text-gray-900">Attribution d'un gestionnaire</p>
-                            <p class="text-sm text-gray-600">Un expert sera assigné à votre dossier sous 24h ouvrées.
+                            <p class="text-sm text-gray-600">Un gestionnaire sera assigné à votre dossier sous 24h ouvrées.
                             </p>
                         </div>
                     </div>
@@ -197,7 +197,7 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                 d="M12 10v6m0 0l-4-4m4 4l4-4m-6 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                         </svg>
-                        Télécharger le reçu PDF
+                        Télécharger votre attestation de déclaration
                     </a>
 
                     <a href="/"

--- a/resources/views/declaration/formulaire.blade.php
+++ b/resources/views/declaration/formulaire.blade.php
@@ -930,7 +930,8 @@
                         'X-Requested-With': 'XMLHttpRequest',
                         'Accept': 'application/json',
                         'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || ''
-                    }
+                    },
+                    credentials: 'same-origin'
                 })
                 .then(async response => {
                     const contentType = response.headers.get('content-type');

--- a/resources/views/declaration/recu-pdf.blade.php
+++ b/resources/views/declaration/recu-pdf.blade.php
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>Reçu de Déclaration - {{ $sinistre->numero_sinistre }}</title>
+    <title>Attestation de Déclaration - {{ $sinistre->numero_sinistre }}</title>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -150,14 +150,14 @@
 </head>
 
 <body>
-    <div class="watermark">SAAR ASSURANCE</div>
+    <div class="watermark">SAAR ASSURANCES</div>
 
     <!-- En-tête -->
     <div class="header">
         <div class="company-name">{{ $company['name'] }}</div>
         <div>{{ $company['address'] }}</div>
         <div>Tél: {{ $company['phone'] }} | Email: {{ $company['email'] }}</div>
-        <div class="document-title">REÇU DE DÉCLARATION DE SINISTRE</div>
+        <div class="document-title">ATTESTATION DE DÉCLARATION DE SINISTRE</div>
     </div>
 
     <!-- Numéro de sinistre -->


### PR DESCRIPTION
Changed the sinistre number format and updated all references from 'reçu' to 'attestation' in PDF generation, file names, and UI texts. Adjusted confirmation messages to mention SMS instead of email and replaced 'expert' with 'gestionnaire'. Also added credentials option to fetch request for improved security.