### PR TITLE
Add unique username to users and update account creation

### DIFF
--- a/app/Jobs/SendAccountCreationSms.php
+++ b/app/Jobs/SendAccountCreationSms.php
@@ -30,15 +30,15 @@ class SendAccountCreationSms implements ShouldQueue
     {
         try {
             $message = "SAAR ASSURANCE\n";
-            $message .= "Votre espace client est prêt:\n";
-            $message .= "Identifiant: {$this->user->numero_assure}\n";
+            $message .= "Votre espace client est prêt :\n";
+            $message .= "Identifiant: {$this->user->username}\n";
             $message .= "Code: {$this->user->password_temp}\n";
             $message .= "Valable 48h\n";
 
             $orangeService->sendSmsConfirmationSinistre(
                 $this->telephone,
                 $this->user->nom_complet,
-                $this->user->numero_assure
+                $this->user->username
             );
         } catch (\Exception $e) {
             Log::error('Erreur lors de l\'envoi du SMS de connexion: ' . $e->getMessage());

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -33,6 +33,7 @@ class User extends Authenticatable
         'sinistres_en_cours',
         'password',
         'numero_assure',
+        'username', 
         'password_temp',
         'password_expire_at',
     ];

--- a/app/Services/AssureAccountService.php
+++ b/app/Services/AssureAccountService.php
@@ -12,11 +12,13 @@ class AssureAccountService
     {
         $numeroAssure = $this->generateAssureNumber();
         $motDePasseTemporaire = $this->generateTemporaryPassword();
+        $username = $this->generateUniqueUsername($data['nom_assure']);
 
         $user = User::create([
             'numero_assure' => $numeroAssure,
             'nom_complet' => $data['nom_assure'],
             'email' => $data['email_assure'] ?? null,
+            'username' => $username,
             'password' => Hash::make($motDePasseTemporaire),
             'password_temp' => $motDePasseTemporaire,
             'password_expires_at' => now()->addHours(48),
@@ -45,5 +47,21 @@ class AssureAccountService
     protected function generateTemporaryPassword(): string
     {
         return str_pad(rand(0, 999999), 6, '0', STR_PAD_LEFT);
+    }
+
+    /**
+     * Génère un username unique basé sur le nom complet
+     */
+    protected function generateUniqueUsername(string $nomComplet): string
+    {
+        // On enlève les accents, espaces, caractères spéciaux, on met en minuscule
+        $base = strtolower(preg_replace('/[^a-z0-9]/', '', iconv('UTF-8', 'ASCII//TRANSLIT', $nomComplet)));
+        $username = $base;
+        $i = 1;
+        while (User::where('username', $username)->exists()) {
+            $username = $base . $i;
+            $i++;
+        }
+        return $username;
     }
 }

--- a/database/migrations/2025_07_21_161200_add_username_to_users.php
+++ b/database/migrations/2025_07_21_161200_add_username_to_users.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            //
+            $table->string('username')->nullable()->unique()->after('email');
         });
     }
 
@@ -22,7 +22,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            //
+            $table->dropColumn('username');
         });
     }
 };


### PR DESCRIPTION
Introduces a unique, auto-generated username for each user. Updates the user model, migration, and account creation service to handle the new username field, and modifies SMS notifications to use the username as the identifier instead of the previous assure number.