### PR TITLE
Reorder 'Utilisateurs' menu item after 'Média' in navbar

### DIFF
--- a/resources/views/admin/partials/navbar.blade.php
+++ b/resources/views/admin/partials/navbar.blade.php
@@ -13,17 +13,6 @@
                 <span class="font-medium">Tableau de bord</span>
             </a>
 
-            <!-- Utilisateurs -->
-            <a href="{{ route('dashboard.users.index') }}"
-                class="menu-item flex items-center space-x-2 px-6 py-4 {{ request()->routeIs('dashboard.users.*') ? 'text-white bg-white/20 border-white' : 'text-white/80 hover:text-white hover:bg-white/10' }} transition-all duration-200 border-b-3 border-transparent hover:border-white/50">
-                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                        d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197m13.5-9a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0z">
-                    </path>
-                </svg>
-                <span class="font-medium">Utilisateurs</span>
-            </a>
-
             <!-- Média -->
             <a href="{{ route('dashboard.media.index') }}"
                 class="menu-item flex items-center space-x-2 px-6 py-4 {{ request()->routeIs('dashboard.media.*') ? 'text-white bg-white/20 border-white' : 'text-white/80 hover:text-white hover:bg-white/10' }} transition-all duration-200 border-b-3 border-transparent hover:border-white/50">
@@ -35,6 +24,17 @@
                     </path>
                 </svg>
                 <span class="font-medium">Média</span>
+            </a>
+
+            <!-- Utilisateurs -->
+            <a href="{{ route('dashboard.users.index') }}"
+                class="menu-item flex items-center space-x-2 px-6 py-4 {{ request()->routeIs('dashboard.users.*') ? 'text-white bg-white/20 border-white' : 'text-white/80 hover:text-white hover:bg-white/10' }} transition-all duration-200 border-b-3 border-transparent hover:border-white/50">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                        d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197m13.5-9a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0z">
+                    </path>
+                </svg>
+                <span class="font-medium">Utilisateurs</span>
             </a>
         </div>
     </div>


### PR DESCRIPTION
Moved the 'Utilisateurs' navigation link below the 'Média' link in the admin navbar for improved menu organization.