### PR TITLE
Add assure login, dashboard, and password change flow

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -26,58 +26,16 @@ class AuthController extends Controller
     }
 
     /**
-     * Traiter la connexion
+     *  connexion des gestionnaires/admins
      */
     public function login(Request $request)
-    {
-        if ($request->has('username')) {
-            return $this->loginAssure($request);
-        }
-        return $this->loginAdminGestionnaire($request);
-    }
-
-    private function loginAssure(Request $request)
-    {
-        $request->validate([
-            'username' => 'required|string',
-            'password' => 'required|min:6',
-        ], [
-            'username.required' => "Le nom d'utilisateur est obligatoire.",
-            'password.required' => 'Le mot de passe est obligatoire.',
-            'password.min' => 'Le mot de passe doit contenir au moins 6 caractères.',
-        ]);
-        $credentials = $request->only('username', 'password');
-        $user = User::where('username', $credentials['username'])->first();
-        if ($user && !$user->actif) {
-            return back()->withErrors([
-                'username' => 'Votre compte est désactivé. Veuillez contacter l\'administrateur.',
-            ])->withInput($request->except('password'));
-        }
-        if (Auth::attempt($credentials)) {
-            $request->session()->regenerate();
-            $user = Auth::user();
-            if ($user->role === 'assure') {
-                return redirect()->route('assures.dashboard')->with('success', 'Connexion réussie !');
-            } else {
-                Auth::logout();
-                return back()->withErrors([
-                    'username' => "Vous n'êtes pas autorisé à accéder à cet espace.",
-                ]);
-            }
-        }
-        return back()->withErrors([
-            'username' => "Les identifiants fournis ne correspondent pas à nos enregistrements.",
-        ])->withInput($request->except('password'));
-    }
-
-    private function loginAdminGestionnaire(Request $request)
     {
         $request->validate([
             'email' => 'required|email',
             'password' => 'required|min:6',
         ], [
-            'email.required' => 'L\'adresse email est obligatoire.',
-            'email.email' => 'L\'adresse email doit être valide.',
+            'email.required' => "L'adresse email est obligatoire.",
+            'email.email' => "L'adresse email doit être valide.",
             'password.required' => 'Le mot de passe est obligatoire.',
             'password.min' => 'Le mot de passe doit contenir au moins 6 caractères.',
         ]);
@@ -91,14 +49,55 @@ class AuthController extends Controller
         if (Auth::attempt($credentials)) {
             $request->session()->regenerate();
             $user = Auth::user();
-            if ($user->role === 'assure') {
-                return redirect()->route('assures.dashboard')->with('success', 'Connexion réussie !');
-            } else {
-                return redirect()->route('dashboard')->with('success', 'Connexion réussie !');
-            }
+            return redirect()->route('dashboard');
         }
         return back()->withErrors([
             'email' => 'Les identifiants fournis ne correspondent pas à nos enregistrements.',
+        ])->withInput($request->except('password'));
+    }
+
+    /**
+     * Traiter la connexion des assurés
+     */
+    public function loginAssure(Request $request)
+    {
+        $request->validate([
+            'username' => 'required|string',
+            'password' => 'required|min:6',
+        ], [
+            'username.required' => "Le nom d'utilisateur est obligatoire.",
+            'password.required' => 'Le mot de passe est obligatoire.',
+            'password.min' => 'Le mot de passe doit contenir au moins 6 caractères.',
+        ]);
+        $credentials = $request->only('username', 'password');
+        $user = User::where('username', $credentials['username'])->first();
+        if (!$user) {
+            return back()->withErrors([
+                'username' => "Aucun utilisateur trouvé avec ce nom d'utilisateur.",
+            ])->withInput($request->except('password'));
+        }
+        if (!$user->actif) {
+            return back()->withErrors([
+                'username' => 'Votre compte est désactivé. Veuillez contacter l\'administrateur.',
+            ])->withInput($request->except('password'));
+        }
+       
+        if (Hash::check($credentials['password'], $user->password)) {
+            
+            if ($user->password_expire_at && $user->password_expire_at->isFuture()) {
+            
+                Auth::login($user);
+                $request->session()->regenerate();
+                return redirect()->route('assure.password.change')->with('info', 'Veuillez changer votre mot de passe temporaire.');
+            }
+            // Authentification normale
+            if (Auth::attempt($credentials)) {
+                $request->session()->regenerate();
+                return redirect()->route('assures.dashboard')->with('success', 'Connexion réussie !');
+            }
+        }
+        return back()->withErrors([
+            'username' => "Les identifiants fournis ne correspondent pas à nos enregistrements.",
         ])->withInput($request->except('password'));
     }
 
@@ -112,6 +111,45 @@ class AuthController extends Controller
         $request->session()->invalidate();
         $request->session()->regenerateToken();
 
-        return redirect('/login')->with('success', 'Vous avez été déconnecté avec succès.');
+        return redirect()->route('login');
+    }
+
+    /**
+     * Déconnexion des assurés
+     */
+    public function logoutAssure(Request $request)
+    {
+        Auth::guard('assure')->logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+        return redirect()->route('login.assure');
+    }
+
+    /**
+     * Affiche le formulaire de changement de mot de passe pour l'assuré
+     */
+    public function showChangePasswordFormAssure()
+    {
+        return view('auth.change_password_assure');
+    }
+
+    /**
+     * Traite le changement de mot de passe pour l'assuré
+     */
+    public function changePasswordAssure(Request $request)
+    {
+        $request->validate([
+            'password' => 'required|min:6|confirmed',
+        ], [
+            'password.required' => 'Le nouveau mot de passe est obligatoire.',
+            'password.min' => 'Le mot de passe doit contenir au moins 6 caractères.',
+            'password.confirmed' => 'La confirmation du mot de passe ne correspond pas.',
+        ]);
+        $user = Auth::user();
+        $user->password = Hash::make($request->password);
+        $user->password_expires_at = null;
+        $user->password_temp = null;
+        $user->save();
+        return redirect()->route('assures.dashboard')->with('success', 'Votre mot de passe a été changé avec succès.');
     }
 }

--- a/app/Http/Controllers/DasboardAssureController.php
+++ b/app/Http/Controllers/DasboardAssureController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class DasboardAssureController extends Controller
+{
+    public function index()
+    {
+        return view('assures.dashboard');
+    }
+}

--- a/app/Services/AssureAccountService.php
+++ b/app/Services/AssureAccountService.php
@@ -21,7 +21,7 @@ class AssureAccountService
             'username' => $username,
             'password' => Hash::make($motDePasseTemporaire),
             'password_temp' => $motDePasseTemporaire,
-            'password_expires_at' => now()->addHours(48),
+            'password_expire_at' => now()->addHours(48),
             'role' => 'assure',
         ]);
 

--- a/config/auth.php
+++ b/config/auth.php
@@ -40,6 +40,10 @@ return [
             'driver' => 'session',
             'provider' => 'users',
         ],
+        'assure' => [
+            'driver' => 'session',
+            'provider' => 'assures',
+        ],
     ],
 
     /*
@@ -63,6 +67,10 @@ return [
         'users' => [
             'driver' => 'eloquent',
             'model' => env('AUTH_MODEL', App\Models\User::class),
+        ],
+        'assures' => [
+            'driver' => 'eloquent',
+            'model' => App\Models\User::class, // À adapter si tu as un modèle spécifique pour les assurés
         ],
 
         // 'users' => [

--- a/resources/views/assures/dashboard.blade.php
+++ b/resources/views/assures/dashboard.blade.php
@@ -1,1 +1,5 @@
-<h1>Bonjour {{ $user->nom_complet }}</h1>
+<h1>Bonjour {{ Auth::user()->nom_complet }}</h1>
+<form method="POST" action="{{ route('logout.assure') }}" style="margin-top: 1rem;">
+    @csrf
+    <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700">Se déconnecter</button>
+</form>

--- a/resources/views/auth/change_password_assure.blade.php
+++ b/resources/views/auth/change_password_assure.blade.php
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Changement de mot de passe - SAAR Assurance</title>
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gradient-to-br from-red-50 via-white to-green-50 min-h-screen">
+    <div class="min-h-screen flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+        <div class="max-w-md w-full space-y-8">
+            <div class="text-center">
+                <h2 class="text-2xl font-bold text-saar-blue mb-2">Changer votre mot de passe</h2>
+                <p class="text-sm text-gray-600">Votre mot de passe temporaire doit être remplacé pour accéder à votre espace assuré.</p>
+            </div>
+            @if ($errors->any())
+                <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-lg" role="alert">
+                    <ul class="list-disc list-inside">
+                        @foreach ($errors->all() as $error)
+                            <li>{{ $error }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+            @endif
+            <form class="mt-8 space-y-6" action="{{ route('assure.password.change.post') }}" method="POST">
+                @csrf
+                <div class="space-y-4">
+                    <div>
+                        <label for="password" class="block text-sm font-medium text-gray-700 mb-2">Nouveau mot de passe</label>
+                        <input id="password" name="password" type="password" required class="appearance-none relative block w-full px-3 py-3 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-lg focus:outline-none focus:ring-2 focus:ring-saar-blue focus:border-saar-blue focus:z-10 sm:text-sm" placeholder="Nouveau mot de passe">
+                    </div>
+                    <div>
+                        <label for="password_confirmation" class="block text-sm font-medium text-gray-700 mb-2">Confirmer le mot de passe</label>
+                        <input id="password_confirmation" name="password_confirmation" type="password" required class="appearance-none relative block w-full px-3 py-3 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-lg focus:outline-none focus:ring-2 focus:ring-saar-blue focus:border-saar-blue focus:z-10 sm:text-sm" placeholder="Confirmez le mot de passe">
+                    </div>
+                </div>
+                <div>
+                    <button type="submit" class="group relative w-full flex justify-center py-3 px-4 border border-transparent text-sm font-medium rounded-lg text-white bg-gradient-to-r from-saar-blue to-blue-600 hover:from-blue-700 hover:to-blue-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-saar-blue transition-all duration-200">Changer le mot de passe</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</body>
+</html> 

--- a/resources/views/auth/login_assure.blade.php
+++ b/resources/views/auth/login_assure.blade.php
@@ -62,7 +62,7 @@
             @endif
 
             <!-- Formulaire de connexion -->
-            <form class="mt-8 space-y-6" action="{{ route('login.post') }}" method="POST">
+            <form class="mt-8 space-y-6" action="{{ route('login.assure.post') }}" method="POST">
                 @csrf
                 <div class="space-y-4">
                     <div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,11 +1,13 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
+use App\Http\Controllers\DasboardAssureController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\DeclarationController;
-use App\Http\Controllers\UserController;
 use App\Http\Controllers\MediaController;
+use App\Http\Controllers\UserController;
+use Illuminate\Support\Facades\Route;
+
 
 Route::get('/', function () {
     return view('welcome');
@@ -25,15 +27,20 @@ Route::middleware(['guest'])->group(function () {
     Route::get('/login', [AuthController::class, 'showLoginForm'])->name('login');
     Route::post('/login', [AuthController::class, 'login'])->name('login.post');
     Route::get('/login/assure', [AuthController::class, 'showLoginAssureForm'])->name('login.assure');
+    Route::post('/login/assure', [AuthController::class, 'loginAssure'])->name('login.assure.post');
 });
 
 
-Route::post('/logout', [AuthController::class, 'logout'])->name('logout')->middleware('auth');
+Route::post('/logout', [AuthController::class, 'logout'])->name('logout');
+Route::post('/assure/logout', [AuthController::class, 'logoutAssure'])->name('logout.assure');
 
 
 Route::middleware(['auth'])->group(function () {
     // Dashboard
     Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
+
+    // Dashboard assuré
+    Route::get('/assures/dashboard', [DasboardAssureController::class, 'index'])->name('assures.dashboard');
 
     Route::prefix('dashboard')->name('dashboard.')->group(function () {
 
@@ -74,5 +81,9 @@ Route::middleware(['auth'])->group(function () {
             Route::delete('/{document}', [MediaController::class, 'destroy'])->name('destroy');
         });
     });
+
+    // Changement de mot de passe temporaire pour les assurés
+    Route::get('/assure/password/change', [AuthController::class, 'showChangePasswordFormAssure'])->name('assure.password.change');
+    Route::post('/assure/password/change', [AuthController::class, 'changePasswordAssure'])->name('assure.password.change.post');
 });
 


### PR DESCRIPTION
Implemented separate authentication and dashboard for 'assure' users, including dedicated login, logout, and password change routes and views. Added DasboardAssureController and updated AuthController to handle assure-specific logic, including temporary password expiration and change. Updated config/auth.php to add 'assure' guard and provider. Adjusted views and routes to support the new assure user flow.