### PR TITLE
Add PWA support with manifest and service worker

### DIFF
--- a/public/js/pwa.js
+++ b/public/js/pwa.js
@@ -1,0 +1,32 @@
+let deferredPrompt;
+window.addEventListener('beforeinstallprompt', (e) => {
+  e.preventDefault();
+  deferredPrompt = e;
+  
+  showInstallPromotion();
+});
+
+function showInstallPromotion() {
+  
+  if (window.matchMedia('(display-mode: standalone)').matches) return;
+  const div = document.createElement('div');
+  div.id = 'pwa-install-prompt';
+  div.style.position = 'fixed';
+  div.style.bottom = '20px';
+  div.style.left = '50%';
+  div.style.transform = 'translateX(-50%)';
+  div.style.background = '#fff';
+  div.style.border = '1px solid #ccc';
+  div.style.padding = '16px';
+  div.style.zIndex = '10000';
+  div.style.boxShadow = '0 2px 8px rgba(0,0,0,0.2)';
+  div.innerHTML = '<span>Installer SaarSinistre sur votre écran d\'accueil ?</span> <button id="pwa-install-btn">Installer</button>';
+  document.body.appendChild(div);
+  document.getElementById('pwa-install-btn').onclick = function() {
+    div.remove();
+    if (deferredPrompt) {
+      deferredPrompt.prompt();
+      deferredPrompt.userChoice.then(() => { deferredPrompt = null; });
+    }
+  };
+} 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "SaarSinistre",
+  "short_name": "Sinistre",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#0d6efd",
+  "description": "Gestion des sinistres en ligne.",
+  "icons": [
+    {
+      "src": "/icons/icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/icons/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+} 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,20 @@
+const CACHE_NAME = 'saarsinistre-cache-v1';
+const urlsToCache = [
+  '/',
+  '/manifest.json',
+  
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME)
+      .then(cache => cache.addAll(urlsToCache))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request)
+      .then(response => response || fetch(event.request))
+  );
+}); 

--- a/resources/views/admin/partials/head.blade.php
+++ b/resources/views/admin/partials/head.blade.php
@@ -2,9 +2,19 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title> {{ $title ?? 'SAAR Assurance' }}</title>
 <meta name="csrf-token" content="{{ csrf_token() }}">
+<link rel="manifest" href="/manifest.json">
+<meta name="theme-color" content="#0d6efd">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 <script src="https://cdn.tailwindcss.com"></script>
 <script src="{{ asset('js/tailwindConfig.js') }}"></script>
+<script>
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', function() {
+      navigator.serviceWorker.register('/sw.js');
+    });
+  }
+</script>
+<script src="/js/pwa.js"></script>
 <style>
     .menu-item.active {
         background: rgba(255, 255, 255, 0.15);

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -5,6 +5,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SAAR Assurance Côte d'Ivoire - Déclaration de Sinistre</title>
+    <link rel="manifest" href="/manifest.json">
+    <meta name="theme-color" content="#0d6efd">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
         tailwind.config = {
@@ -56,6 +58,14 @@
             }
         }
     </script>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', function() {
+          navigator.serviceWorker.register('/sw.js');
+        });
+      }
+    </script>
+    <script src="/js/pwa.js"></script>
 </head>
 
 <body class="bg-gradient-to-br from-red-50 via-white to-green-50 min-h-screen overflow-x-hidden">


### PR DESCRIPTION
Introduces Progressive Web App (PWA) features by adding a manifest.json, a service worker (sw.js), and a PWA install prompt (pwa.js). Updates head sections in admin and welcome views to register the service worker, include the manifest, set the theme color, and load the PWA script. This enables offline support and installability for the application.