### PR TITLE
Add role-based access control and refactor authentication

### DIFF
--- a/app/Http/Middleware/CheckRole.php
+++ b/app/Http/Middleware/CheckRole.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckRole
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next, ...$roles): Response
+    {
+        if (!Auth::check()) {
+            return redirect()->route('login');
+        }
+
+        $user = Auth::user();
+
+        if (!in_array($user->role, $roles)) {
+            Auth::logout();
+            $request->session()->invalidate();
+            $request->session()->regenerateToken();
+
+            return redirect()->route('login')->withErrors([
+                'email' => 'Accès non autorisé. Vous avez été déconnecté.',
+            ]);
+        }
+        
+        return $next($request);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -13,12 +13,6 @@ class User extends Authenticatable
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasFactory, Notifiable;
 
-    /**
-     * The user's role.
-     *
-     * @var string|null
-     */
-    public $role;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Services/SinistreDocumentService.php
+++ b/app/Services/SinistreDocumentService.php
@@ -2,9 +2,10 @@
 
 namespace App\Services;
 
+use App\Models\DocumentSinistre;
 use App\Models\Sinistre;
 use Illuminate\Http\Request;
-use App\Models\DocumentSinistre;
+use Illuminate\Support\Facades\Storage;
 
 class SinistreDocumentService
 {

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,7 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'role' => \App\Http\Middleware\CheckRole::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -62,7 +62,7 @@
             @endif
 
             <!-- Formulaire de connexion -->
-            <form class="mt-8 space-y-6" action="{{ route('login') }}" method="POST">
+            <form class="mt-8 space-y-6" action="{{ route('login.post') }}" method="POST">
                 @csrf
                 <div class="space-y-4">
                     <div>

--- a/routes/assures.php
+++ b/routes/assures.php
@@ -1,9 +1,10 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\DasboardAssureController;
-use App\Http\Controllers\DeclarationController;
 use App\Http\Controllers\AuthController;
+use App\Http\Controllers\ChatController;
+use App\Http\Controllers\DeclarationController;
+use App\Http\Controllers\DasboardAssureController;
 
 //Authentification
 Route::middleware(['guest'])->group(function () {


### PR DESCRIPTION
Introduces a CheckRole middleware for enforcing role-based access to routes, updates authentication logic in AuthController to separate and clarify login flows for 'assure' and admin/gestionnaire users, and applies middleware to relevant route groups. Refactors User model to remove unused public $role property. Updates login form action and route definitions to align with new authentication structure.