### PR TITLE
Ajout de nouvelles statistiques pour les sinistres dans le Dashboard gestionnaire

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -16,7 +16,10 @@ class DashboardController extends Controller
             'en_attente' => Sinistre::where('statut', 'en_attente')->count(),
             'traites' => Sinistre::whereIn('statut', ['regle', 'clos'])->count(),
             'expertise_requise' => Sinistre::where('statut', 'expertise_requise')->count(),
-            'en_cours' => Sinistre::where('statut', 'en_cours')->count()
+            'en_cours' => Sinistre::where('statut', 'en_cours')->count(),
+            'en_retard' => Sinistre::where('en_retard', true)->count(),
+            'en_attente_documents' => Sinistre::where('statut', 'en_attente_documents')->count(),
+            'refuse' => Sinistre::where('statut', 'refuse')->count(),
         ];
 
         $gestionnaires = User::gestionnaires()
@@ -30,12 +33,7 @@ class DashboardController extends Controller
     {
         $sinistre = Sinistre::with(['gestionnaire', 'documents'])
             ->findOrFail($id);
-        
-       
-        $sinistre->documents->each(function ($document) {
-            $document->url = asset('storage/' . $document->chemin_fichier);
-        });
-    
+
         return response()->json([
             'sinistre' => $sinistre,
         ]);
@@ -192,6 +190,7 @@ class DashboardController extends Controller
             'en_retard' => Sinistre::where('en_retard', true)->count(),
             'expertise_requise' => Sinistre::where('statut', 'expertise_requise')->count(),
             'en_attente_documents' => Sinistre::where('statut', 'en_attente_documents')->count(),
+            'refuse' => Sinistre::where('statut', 'refuse')->count(),
         ];
 
         $statsByGestionnaire = Sinistre::select('gestionnaire_id')

--- a/app/Models/DocumentSinistre.php
+++ b/app/Models/DocumentSinistre.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Storage;
 
 class DocumentSinistre extends Model
 {
+    protected $appends = ['url'];
     protected $fillable = [
         'sinistre_id',
         'type_document',

--- a/public/js/Dashboard/sinistres.js
+++ b/public/js/Dashboard/sinistres.js
@@ -288,6 +288,17 @@ class SinistresManager {
             stats.en_attente;
         document.getElementById("stat-traites").textContent = stats.traites;
         document.getElementById("stat-en-cours").textContent = stats.en_cours;
+        const exp = document.getElementById("stat-expertise-requise");
+        if (exp) exp.textContent = stats.expertise_requise;
+
+        const enRetard = document.getElementById("stat-en-retard");
+        if (enRetard) enRetard.textContent = stats.en_retard;
+
+        const enAttenteDocs = document.getElementById("stat-en-attente-documents");
+        if (enAttenteDocs) enAttenteDocs.textContent = stats.en_attente_documents;
+
+        const refuses = document.getElementById("stat-refuse");
+        if (refuses) refuses.textContent = stats.refuse;
     }
 }
 

--- a/resources/views/admin/partials/stats-cards.blade.php
+++ b/resources/views/admin/partials/stats-cards.blade.php
@@ -70,8 +70,49 @@
             </div>
             <div class="ml-4">
                 <p class="text-sm font-medium text-gray-600">Expertise Requise</p>
-                <p id="stat-expertise-requise" class="text-2xl font-bold text-gray-900">
-                    {{ $stats['expertise_requise'] }}</p>
+                <p id="stat-expertise-requise" class="text-2xl font-bold text-gray-900">{{ $stats['expertise_requise'] }}</p>
+            </div>
+        </div>
+    </div>
+
+    <div class="bg-white rounded-2xl shadow-lg p-6 border border-gray-100 hover:shadow-xl transition-all duration-300">
+        <div class="flex items-center">
+            <div class="p-3 rounded-xl bg-orange-100">
+                <svg class="w-6 h-6 text-orange-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                </svg>
+            </div>
+            <div class="ml-4">
+                <p class="text-sm font-medium text-gray-600">En attente de documents</p>
+                <p id="stat-en-attente-documents" class="text-2xl font-bold text-gray-900">{{ $stats['en_attente_documents'] }}</p>
+            </div>
+        </div>
+    </div>
+
+    <div class="bg-white rounded-2xl shadow-lg p-6 border border-gray-100 hover:shadow-xl transition-all duration-300">
+        <div class="flex items-center">
+            <div class="p-3 rounded-xl bg-red-100">
+                <svg class="w-6 h-6 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636M18.364 5.636L5.636 18.364"></path>
+                </svg>
+            </div>
+            <div class="ml-4">
+                <p class="text-sm font-medium text-gray-600">Refusés</p>
+                <p id="stat-refuse" class="text-2xl font-bold text-gray-900">{{ $stats['refuse'] }}</p>
+            </div>
+        </div>
+    </div>
+
+    <div class="bg-white rounded-2xl shadow-lg p-6 border border-gray-100 hover:shadow-xl transition-all duration-300">
+        <div class="flex items-center">
+            <div class="p-3 rounded-xl bg-rose-100">
+                <svg class="w-6 h-6 text-rose-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                </svg>
+            </div>
+            <div class="ml-4">
+                <p class="text-sm font-medium text-gray-600">En retard</p>
+                <p id="stat-en-retard" class="text-2xl font-bold text-gray-900">{{ $stats['en_retard'] }}</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Ajout de nouvelles statistiques pour les sinistres dans le Dashboard : en retard, en attente de documents et refusés. Mise à jour de l'affichage des statistiques dans le JavaScript et le template Blade correspondant.