### PR TITLE
Modification de la méthode assignerGestionnaire dans le modèle Sinistre

### DIFF
--- a/app/Models/Sinistre.php
+++ b/app/Models/Sinistre.php
@@ -163,11 +163,18 @@ class Sinistre extends Model
      */
     public function assignerGestionnaire($gestionnaireId): void
     {
-        $this->update([
+        $attributes = [
             'gestionnaire_id' => $gestionnaireId,
             'date_affectation' => now(),
-            'statut' => 'en_cours'
-        ]);
+        ];
+
+        if (is_null($this->gestionnaire_id) && $gestionnaireId) {
+            if ($this->statut === 'en_attente') {
+                $attributes['statut'] = 'en_cours';
+            }
+        }
+
+        $this->update($attributes);
     }
 
     /**


### PR DESCRIPTION
Modification de la méthode assignerGestionnaire dans le modèle Sinistre pour mettre à jour le statut en 'en_cours' uniquement si le gestionnaire est affecté et que le statut précédent était 'en_attente'. Amélioration de la gestion des attributs avant la mise à jour. 