### PR TITLE
Correction de la logique de calcul des jours en cours 

### DIFF
--- a/app/Console/Commands/NotifyUnassignedSinistres.php
+++ b/app/Console/Commands/NotifyUnassignedSinistres.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Carbon\Carbon;
+use App\Models\User;
+use App\Models\Sinistre;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use App\Jobs\SendSinistreNotificationEmail;
+
+class NotifyUnassignedSinistres extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * Option --date=YYYY-MM-DD permet de forcer la date de recherche.
+     */
+    protected $signature = 'sinistres:notify-unassigned {--date=}';
+
+    /**
+     * The console command description.
+     */
+    protected $description = 'Notifier tous les gestionnaires pour les sinistres non affectés déclarés la veille.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $dateOption = $this->option('date');
+        $targetDate = $dateOption
+            ? Carbon::parse($dateOption)->startOfDay()
+            : now()->subDay()->startOfDay();
+
+        $this->info('Recherche des sinistres non affectés pour la date: ' . $targetDate->toDateString());
+
+        $sinistres = Sinistre::query()
+            ->whereNull('gestionnaire_id')
+            ->whereDate('created_at', $targetDate->toDateString())
+            ->whereNull('derniere_notification')
+            ->get();
+
+        if ($sinistres->isEmpty()) {
+            $this->info('Aucun sinistre à notifier.');
+            return self::SUCCESS;
+        }
+
+        $gestionnaires = User::query()
+            ->where('role', 'gestionnaire')
+            ->where('actif', true)
+            ->get();
+
+        if ($gestionnaires->isEmpty()) {
+            Log::warning('Aucun gestionnaire actif trouvé pour la notification des sinistres non affectés.', [
+                'date_cible' => $targetDate->toDateString(),
+                'nb_sinistres' => $sinistres->count(),
+            ]);
+            $this->warn('Aucun gestionnaire actif.');
+            return self::SUCCESS;
+        }
+
+        foreach ($sinistres as $sinistre) {
+            try {
+                SendSinistreNotificationEmail::dispatch($sinistre, $gestionnaires);
+                $sinistre->update(['derniere_notification' => now()]);
+                $this->info('Notification planifiée pour le sinistre: ' . $sinistre->numero_sinistre);
+            } catch (\Throwable $e) {
+                Log::error('Erreur lors de la planification de notification pour un sinistre non affecté.', [
+                    'sinistre_id' => $sinistre->id,
+                    'numero_sinistre' => $sinistre->numero_sinistre,
+                    'error' => $e->getMessage(),
+                ]);
+                $this->error('Echec de notification pour: ' . $sinistre->numero_sinistre);
+            }
+        }
+
+        return self::SUCCESS;
+    }
+}
+
+

--- a/app/Models/Sinistre.php
+++ b/app/Models/Sinistre.php
@@ -154,7 +154,7 @@ class Sinistre extends Model
     {
         $createdAt = $this->getAttribute('created_at');
         $this->jours_en_cours = $createdAt ? $createdAt->diffInDays(now()) : 0;
-        $this->en_retard = $this->jours_en_cours > 15; // Seuil de 15 jours
+        $this->en_retard = $this->jours_en_cours > 15;
         $this->save();
     }
 

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,6 +2,9 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
+
+Schedule::command('sinistres:notify-unassigned')->dailyAt('14:30');
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());


### PR DESCRIPTION
Correction de la logique de calcul des jours en cours dans le modèle Sinistre et ajout d'une tâche planifiée pour notifier les sinistres non assignés quotidiennement à 14h30. 