### PR TITLE
Ajout de l'envoi de SMS lors du changement de statut d'un sinistre et…

### DIFF
--- a/app/Console/Commands/TestAccountCreation.php
+++ b/app/Console/Commands/TestAccountCreation.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use App\Models\Sinistre;
+use App\Services\AssureAccountService;
+use App\Services\OrangeService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class TestAccountCreation extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'test:account-creation {nom_assure} {email_assure?} {telephone_assure?}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Tester la logique de création de compte assuré';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $nomAssure = $this->argument('nom_assure');
+        $emailAssure = $this->argument('email_assure');
+        $telephoneAssure = $this->argument('telephone_assure');
+
+        $this->info("=== Test de la logique de création de compte ===");
+        $this->info("Nom: {$nomAssure}");
+        $this->info("Email: " . ($emailAssure ?: 'non fourni'));
+        $this->info("Téléphone: " . ($telephoneAssure ?: 'non fourni'));
+        $this->line("");
+
+        $data = [
+            'nom_assure' => $nomAssure,
+            'email_assure' => $emailAssure,
+            'telephone_assure' => $telephoneAssure,
+        ];
+
+        try {
+            // Simuler la logique du contrôleur
+            $user = null;
+            
+            // 1. Chercher par email exact
+            if (!empty($data['email_assure'])) {
+                $user = User::where('email', $data['email_assure'])
+                           ->where('role', 'assure')
+                           ->first();
+                           
+                if ($user) {
+                    $this->info("✅ Utilisateur trouvé par email: {$user->nom_complet} (ID: {$user->id})");
+                } else {
+                    $this->info("❌ Aucun utilisateur trouvé avec l'email: {$data['email_assure']}");
+                }
+            }
+            
+            // 2. Chercher par téléphone et nom
+            if (!$user && !empty($data['telephone_assure'])) {
+                $sinistreExistant = Sinistre::where('telephone_assure', $data['telephone_assure'])
+                                          ->where('nom_assure', $data['nom_assure'])
+                                          ->whereNotNull('assure_id')
+                                          ->first();
+                
+                if ($sinistreExistant && $sinistreExistant->assure_id) {
+                    $user = User::find($sinistreExistant->assure_id);
+                    $this->info("✅ Utilisateur trouvé via sinistre existant: {$user->nom_complet} (ID: {$user->id})");
+                    $this->info("   Sinistre: {$sinistreExistant->numero_sinistre}");
+                } else {
+                    $this->info("❌ Aucun sinistre trouvé avec téléphone: {$data['telephone_assure']} et nom: {$nomAssure}");
+                }
+            }
+
+            // 3. Créer un nouveau compte si nécessaire
+            if (!$user) {
+                $this->info("🔄 Création d'un nouveau compte...");
+                
+                // Simuler la création (sans vraiment créer pour le test)
+                $this->info("✅ Un nouveau compte sera créé");
+                $this->info("📧 Un SMS sera envoyé avec les identifiants");
+                
+                // Pour un vrai test, décommentez cette ligne :
+                // $user = (new AssureAccountService)->createAssureAccount($data, app(OrangeService::class));
+            } else {
+                $this->info("ℹ️  Utilisation du compte existant - AUCUN SMS ne sera envoyé");
+            }
+
+            $this->line("");
+            $this->info("=== Résumé ===");
+            if ($user) {
+                $this->info("Compte utilisé: {$user->nom_complet}");
+                $this->info("Email: " . ($user->email ?: 'non défini'));
+                $this->info("Username: {$user->username}");
+            } else {
+                $this->info("Un nouveau compte serait créé");
+            }
+
+            return 0;
+            
+        } catch (\Exception $e) {
+            $this->error("Erreur lors du test: " . $e->getMessage());
+            Log::error('Erreur test account creation', [
+                'nom_assure' => $nomAssure,
+                'error' => $e->getMessage()
+            ]);
+            return 1;
+        }
+    }
+}

--- a/app/Console/Commands/TestSmsAssignment.php
+++ b/app/Console/Commands/TestSmsAssignment.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Sinistre;
+use App\Models\User;
+use App\Jobs\SendGestionnaireAssignmentSms;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class TestSmsAssignment extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'sms:test-assignment {sinistre_id} {gestionnaire_id}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Tester l\'envoi de SMS d\'affectation de gestionnaire';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $sinistreId = $this->argument('sinistre_id');
+        $gestionnaireId = $this->argument('gestionnaire_id');
+
+        try {
+            $sinistre = Sinistre::findOrFail($sinistreId);
+            $gestionnaire = User::findOrFail($gestionnaireId);
+
+            if (!$gestionnaire->estGestionnaire()) {
+                $this->error('L\'utilisateur spécifié n\'est pas un gestionnaire.');
+                return 1;
+            }
+
+            $this->info("Test d'affectation du sinistre {$sinistre->numero_sinistre} au gestionnaire {$gestionnaire->nom_complet}");
+            
+            // Simuler l'affectation
+            $ancienGestionnaire = $sinistre->gestionnaire_id;
+            $sinistre->assignerGestionnaire($gestionnaireId);
+
+            $this->info("✅ Sinistre affecté avec succès !");
+            $this->info("📧 Un SMS sera envoyé à l'assuré dans quelques secondes...");
+            
+            if ($ancienGestionnaire) {
+                $this->info("ℹ️  Ancien gestionnaire: {$ancienGestionnaire}");
+            }
+            
+            $this->info("ℹ️  Nouveau gestionnaire: {$gestionnaireId}");
+            $this->info("ℹ️  Statut du sinistre: {$sinistre->fresh()->statut}");
+
+            return 0;
+        } catch (\Exception $e) {
+            $this->error("Erreur lors du test: " . $e->getMessage());
+            Log::error('Erreur lors du test SMS assignment', [
+                'sinistre_id' => $sinistreId,
+                'gestionnaire_id' => $gestionnaireId,
+                'error' => $e->getMessage()
+            ]);
+            return 1;
+        }
+    }
+}

--- a/app/Console/Commands/TestSmsStatusUpdate.php
+++ b/app/Console/Commands/TestSmsStatusUpdate.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Sinistre;
+use App\Jobs\SendSinistreStatusUpdateSms;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class TestSmsStatusUpdate extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'sms:test-status {sinistre_id} {nouveau_statut}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Tester l\'envoi de SMS de changement de statut';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $sinistreId = $this->argument('sinistre_id');
+        $nouveauStatut = $this->argument('nouveau_statut');
+
+        $statutsValides = ['en_attente', 'en_cours', 'expertise_requise', 'en_attente_documents', 'pret_reglement', 'regle', 'refuse', 'clos'];
+
+        if (!in_array($nouveauStatut, $statutsValides)) {
+            $this->error('Statut invalide. Statuts valides: ' . implode(', ', $statutsValides));
+            return 1;
+        }
+
+        try {
+            $sinistre = Sinistre::findOrFail($sinistreId);
+            $ancienStatut = $sinistre->statut;
+
+            if ($ancienStatut === $nouveauStatut) {
+                $this->error('Le nouveau statut est identique au statut actuel.');
+                return 1;
+            }
+
+            $this->info("Test de changement de statut du sinistre {$sinistre->numero_sinistre}");
+            $this->info("Ancien statut: {$ancienStatut}");
+            $this->info("Nouveau statut: {$nouveauStatut}");
+            
+            // Changer le statut
+            $sinistre->update(['statut' => $nouveauStatut]);
+
+            // Déclencher manuellement l'envoi du SMS pour le test
+            SendSinistreStatusUpdateSms::dispatch($sinistre, $ancienStatut);
+
+            $this->info("✅ Statut modifié avec succès !");
+            $this->info("📧 Un SMS sera envoyé à l'assuré dans quelques secondes...");
+            
+            return 0;
+        } catch (\Exception $e) {
+            $this->error("Erreur lors du test: " . $e->getMessage());
+            Log::error('Erreur lors du test SMS status update', [
+                'sinistre_id' => $sinistreId,
+                'nouveau_statut' => $nouveauStatut,
+                'error' => $e->getMessage()
+            ]);
+            return 1;
+        }
+    }
+}

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -152,8 +152,11 @@ class DashboardController extends Controller
             $sinistre->reglerSinistre($request->montant_regle);
         }
 
-        //TODO: send sms after status (en cours) change
-        //TODOD: save history of status change
+        // Envoyer un SMS à l'assuré si le statut a changé
+        if ($ancienStatut !== $request->statut) {
+            \App\Jobs\SendSinistreStatusUpdateSms::dispatch($sinistre, $ancienStatut)
+                ->delay(now()->addSeconds(10));
+        }
 
         return response()->json([
             'success' => true,

--- a/app/Jobs/SendGestionnaireAssignmentSms.php
+++ b/app/Jobs/SendGestionnaireAssignmentSms.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Sinistre;
+use App\Services\OrangeService;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class SendGestionnaireAssignmentSms implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public Sinistre $sinistre
+    ) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(OrangeService $orangeService): void
+    {
+        try {
+            if (!$this->sinistre->assure_id || !$this->sinistre->gestionnaire_id) {
+                Log::warning('Sinistre sans assuré ou gestionnaire pour SMS d\'affectation', [
+                    'sinistre_id' => $this->sinistre->id,
+                    'numero_sinistre' => $this->sinistre->numero_sinistre,
+                    'assure_id' => $this->sinistre->assure_id,
+                    'gestionnaire_id' => $this->sinistre->gestionnaire_id
+                ]);
+                return;
+            }
+
+            $this->sinistre->load(['assure', 'gestionnaire']);
+
+            $assure = $this->sinistre->assure;
+            $gestionnaire = $this->sinistre->gestionnaire;
+
+            $telephoneAssure = $this->sinistre->telephone_assure ?? $assure->telephone ?? null;
+            
+            if (empty($telephoneAssure)) {
+                Log::warning('Numéro de téléphone manquant pour SMS d\'affectation de gestionnaire', [
+                    'sinistre_id' => $this->sinistre->id,
+                    'numero_sinistre' => $this->sinistre->numero_sinistre,
+                    'assure_id' => $assure->id
+                ]);
+                return;
+            }
+
+            $nomAssure = strtoupper(explode(' ', trim($assure->nom_complet ?? $this->sinistre->nom_assure))[0]);
+            $nomGestionnaire = $gestionnaire->nom_complet ?? 'Gestionnaire';
+            $statutLibelle = $this->sinistre->statut_libelle;
+            
+            $message = "SAAR ASSURANCE\nCher(e) {$nomAssure}, votre sinistre N°{$this->sinistre->numero_sinistre} a ete affecte a {$nomGestionnaire}. Statut: {$statutLibelle}. Vous serez contacte(e) prochainement.";
+
+            if (strlen($message) > 160) {
+                $message = "SAAR ASSURANCE\nSinistre N°{$this->sinistre->numero_sinistre} affecte a un gestionnaire. Statut: {$statutLibelle}. Vous serez contacte prochainement.";
+            }
+
+            $result = $orangeService->sendSMS(
+                $telephoneAssure,
+                $message,
+                'SAAR CI'
+            );
+
+            Log::info('SMS d\'affectation de gestionnaire envoyé avec succès', [
+                'sinistre_id' => $this->sinistre->id,
+                'numero_sinistre' => $this->sinistre->numero_sinistre,
+                'telephone_assure' => $telephoneAssure,
+                'gestionnaire_nom' => $nomGestionnaire,
+                'statut' => $this->sinistre->statut,
+                'message_length' => strlen($message),
+                'response' => $result
+            ]);
+
+        } catch (\Exception $e) {
+            Log::error('Erreur lors de l\'envoi du SMS d\'affectation de gestionnaire', [
+                'sinistre_id' => $this->sinistre->id,
+                'numero_sinistre' => $this->sinistre->numero_sinistre,
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString()
+            ]);
+
+            throw $e;
+        }
+    }
+}

--- a/app/Jobs/SendSinistreStatusUpdateSms.php
+++ b/app/Jobs/SendSinistreStatusUpdateSms.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Sinistre;
+use App\Services\OrangeService;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class SendSinistreStatusUpdateSms implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public Sinistre $sinistre,
+        public string $ancienStatut
+    ) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(OrangeService $orangeService): void
+    {
+        try {
+            if (!$this->sinistre->assure_id) {
+                Log::warning('Sinistre sans assuré pour SMS de changement de statut', [
+                    'sinistre_id' => $this->sinistre->id,
+                    'numero_sinistre' => $this->sinistre->numero_sinistre
+                ]);
+                return;
+            }
+
+            $this->sinistre->load(['assure', 'gestionnaire']);
+
+            $assure = $this->sinistre->assure;
+
+            $telephoneAssure = $this->sinistre->telephone_assure ?? $assure->telephone ?? null;
+            
+            if (empty($telephoneAssure)) {
+                Log::warning('Numéro de téléphone manquant pour SMS de changement de statut', [
+                    'sinistre_id' => $this->sinistre->id,
+                    'numero_sinistre' => $this->sinistre->numero_sinistre,
+                    'assure_id' => $assure->id
+                ]);
+                return;
+            }
+
+            $statutsNotifiables = ['en_cours', 'expertise_requise', 'pret_reglement', 'regle', 'refuse', 'clos'];
+            
+            if (!in_array($this->sinistre->statut, $statutsNotifiables)) {
+                Log::info('Statut non notifiable par SMS', [
+                    'sinistre_id' => $this->sinistre->id,
+                    'statut' => $this->sinistre->statut
+                ]);
+                return;
+            }
+
+            $nomAssure = strtoupper(explode(' ', trim($assure->nom_complet ?? $this->sinistre->nom_assure))[0]);
+            $statutLibelle = $this->sinistre->statut_libelle;
+            
+            $message = "SAAR ASSURANCE\nCher(e) {$nomAssure}, le statut de votre sinistre N°{$this->sinistre->numero_sinistre} a ete mis a jour: {$statutLibelle}.";
+
+            switch ($this->sinistre->statut) {
+                case 'expertise_requise':
+                    $message .= " Un expert va vous contacter prochainement.";
+                    break;
+                case 'pret_reglement':
+                    $message .= " Votre dossier est pret pour le reglement.";
+                    break;
+                case 'regle':
+                    $message .= " Votre sinistre a ete regle. Merci de votre confiance.";
+                    break;
+                case 'refuse':
+                    $message .= " Veuillez contacter votre gestionnaire pour plus d'informations.";
+                    break;
+                case 'clos':
+                    $message .= " Votre dossier est maintenant clos.";
+                    break;
+                default:
+                    $message .= " Vous serez contacte(e) si necessaire.";
+                    break;
+            }
+
+            // Vérifier la longueur du message et le raccourcir si nécessaire
+            if (strlen($message) > 160) {
+                $message = "SAAR ASSURANCE\nSinistre N°{$this->sinistre->numero_sinistre}: {$statutLibelle}. Contactez votre gestionnaire si necessaire.";
+            }
+
+            // Envoyer le SMS
+            $result = $orangeService->sendSMS(
+                $telephoneAssure,
+                $message,
+                'SAAR CI'
+            );
+
+            Log::info('SMS de changement de statut envoyé avec succès', [
+                'sinistre_id' => $this->sinistre->id,
+                'numero_sinistre' => $this->sinistre->numero_sinistre,
+                'telephone_assure' => $telephoneAssure,
+                'ancien_statut' => $this->ancienStatut,
+                'nouveau_statut' => $this->sinistre->statut,
+                'message_length' => strlen($message),
+                'response' => $result
+            ]);
+
+        } catch (\Exception $e) {
+            Log::error('Erreur lors de l\'envoi du SMS de changement de statut', [
+                'sinistre_id' => $this->sinistre->id,
+                'numero_sinistre' => $this->sinistre->numero_sinistre,
+                'ancien_statut' => $this->ancienStatut,
+                'nouveau_statut' => $this->sinistre->statut,
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString()
+            ]);
+
+            // Relancer l'exception pour permettre les tentatives de retry
+            throw $e;
+        }
+    }
+}

--- a/app/Jobs/SendUserCredentialsEmail.php
+++ b/app/Jobs/SendUserCredentialsEmail.php
@@ -60,7 +60,6 @@ class SendUserCredentialsEmail implements ShouldQueue
                 'error' => $e->getMessage()
             ]);
 
-            // Relancer le job en cas d'échec
             throw $e;
         }
     }

--- a/app/Models/Sinistre.php
+++ b/app/Models/Sinistre.php
@@ -2,12 +2,13 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Database\Eloquent\Model;
+use App\Jobs\SendGestionnaireAssignmentSms;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Sinistre extends Model
 {
@@ -184,6 +185,8 @@ class Sinistre extends Model
      */
     public function assignerGestionnaire($gestionnaireId): void
     {
+        $ancienGestionnaireId = $this->gestionnaire_id;
+        
         $attributes = [
             'gestionnaire_id' => $gestionnaireId,
             'date_affectation' => now(),
@@ -196,6 +199,11 @@ class Sinistre extends Model
         }
 
         $this->update($attributes);
+
+        if ($gestionnaireId && $gestionnaireId !== $ancienGestionnaireId) {
+            SendGestionnaireAssignmentSms::dispatch($this)
+                ->delay(now()->addSeconds(5));
+        }
     }
 
     /**


### PR DESCRIPTION
… amélioration de la vérification de l'utilisateur lors de la déclaration. Ajout de logs pour le suivi des comptes assurés créés ou utilisés. Suppression de la relance automatique des jobs en cas d'échec dans l'envoi des informations d'identification.