### PR TITLE
chore: Update Vite build configuration to specify manifest file name

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -9,7 +9,7 @@ export default defineConfig({
         }),
     ],
     build: {
-        manifest: true,
+        manifest: 'manifest.json',
         outDir: 'public/build',
         rollupOptions: {
             output: {


### PR DESCRIPTION
- Changed the manifest option in vite.config.js to explicitly define the output file name as 'manifest.json' for clarity and consistency in asset management.